### PR TITLE
Fix #1 for Colored Shulker Boxes

### DIFF
--- a/src/main/java/megaminds/clickopener/Config.java
+++ b/src/main/java/megaminds/clickopener/Config.java
@@ -115,6 +115,10 @@ public class Config {
 	}
 
 	public boolean isAllowed(String name) {
+		if (name.endsWith("shulker_box")) {
+			name = "shulker_box";	
+		}
+		
 		return switch (name) {
 		case "smithing_table" -> smithingTable;
 		case "crafting_table" -> craftingTable;


### PR DESCRIPTION
Colored shulker boxes currently do not work because the config check doesn't recognize colored shulker boxes as being allowed. This PR makes the config check agnostic to the color of the shulker.